### PR TITLE
Use Syck not Psych

### DIFF
--- a/lib/jenkins/api.rb
+++ b/lib/jenkins/api.rb
@@ -2,9 +2,12 @@ require 'httparty'
 require 'cgi'
 require 'uri'
 require 'json'
+require 'yaml'
 
 require 'jenkins/core_ext/hash'
 require 'jenkins/config'
+
+YAML::ENGINE.yamler = "syck"
 
 module Jenkins
   module Api


### PR DESCRIPTION
Crack doesn't handle Psych errors[1] correctly.  So this change forces the YAML parse to be
Syck on newer versions of Ruby.

[1] https://github.com/jnunemaker/crack/issues/26
