### PR TITLE
Add support for passing basic_auth in the host option as part of the uri

### DIFF
--- a/lib/jenkins/api.rb
+++ b/lib/jenkins/api.rb
@@ -26,6 +26,8 @@ module Jenkins
       # Thor's HashWithIndifferentAccess is based on string keys which URI::HTTP.build ignores
       options = options.inject({}) { |mem, (key, val)| mem[key.to_sym] = val; mem }
 
+      options = setup_authentication(options)
+
       # Handle URL style hosts by parsing the URL
       if options.keys.length == 1 && options.key?(:host)
         parsed_uri = URI::parse(options[:host])
@@ -35,9 +37,11 @@ module Jenkins
             :path => parsed_uri.path,
             :ssl => parsed_uri.scheme == 'https'
             }
+        if parsed_uri.user && parsed_uri.password
+          basic_auth parsed_uri.user, parsed_uri.password
+        end
       end
 
-      options = setup_authentication(options)
       options[:host] ||= ENV['JENKINS_HOST']
       options[:port] ||= ENV['JENKINS_PORT']
       options[:port] &&= options[:port].to_i

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -24,6 +24,16 @@ describe Jenkins::Api do
       uri.path.should == ''
     end
 
+    it "should accept basic auth parameters in the :host argument" do
+      uri = Jenkins::Api.setup_base_url :host => 'http://foo:bar@string.example.com:2'
+      uri.host.should == 'string.example.com'
+      uri.port.should == 2
+      uri.path.should == ''
+      auth = Jenkins::Api.default_options[:basic_auth]
+      auth[:username].should == 'foo'
+      auth[:password].should == 'bar'
+    end
+
     context "with environment variables" do
       after :each do
         ENV.delete 'JENKINS_HOST'


### PR DESCRIPTION
Adds support for:

```
jenkins list --host http://foo:bar@example.org/
```
