### PR TITLE
handled java command when it's symlink

### DIFF
--- a/ruby-tools/jpi/lib/jenkins/plugin/tools/server.rb
+++ b/ruby-tools/jpi/lib/jenkins/plugin/tools/server.rb
@@ -47,7 +47,7 @@ module Jenkins
 #          args << "-Djruby.debug.loadService.timing=true"
           args << "-jar"
           args << @war
-          exec *args
+          exec args.join(' ')
         end
       end
     end


### PR DESCRIPTION
java command is symlink for some of Linux environment, ex. gentoo. Kernel.exec doesn't extract symlink to real path when given Array.

fixed Array to String, it's joined with whitespace.
