### PR TITLE
Remove a bad error message advertising an --xml output format

### DIFF
--- a/ruby-tools/cli/lib/jenkins/cli.rb
+++ b/ruby-tools/cli/lib/jenkins/cli.rb
@@ -166,7 +166,7 @@ module Jenkins
           require "yaml"
           puts job.parsed_response.to_yaml
         else
-          error "Select an output format: --json, --xml, --yaml, --hash"
+          error "Select an output format: --json, --yaml, --hash"
         end
       else
         error "Cannot find project '#{name}'."

--- a/ruby-tools/cli/lib/jenkins/job_config_builder.rb
+++ b/ruby-tools/cli/lib/jenkins/job_config_builder.rb
@@ -10,16 +10,16 @@ module Jenkins
     attr_accessor :scm, :public_scm, :scm_branches
     attr_accessor :assigned_node, :node_labels # TODO just one of these
     attr_accessor :envfile
-    
+
     InvalidTemplate = Class.new(StandardError)
-    
+
     VALID_JOB_TEMPLATES = %w[none rails rails3 ruby rubygem erlang]
     JOB_TRIGGER_THRESHOLDS = {
       "SUCCESS"  => {:ordinal => 0, :color => "BLUE"},
       "UNSTABLE" => {:ordinal => 1, :color => "YELLOW"},
       "FAILURE"  => {:ordinal => 2, :color => "RED"}
     }
-    
+
     # +job_type+ - template of default steps to create with the job
     # +steps+ - array of [:method, cmd], e.g. [:build_shell_step, "bundle initial"]
     #   - Default is based on +job_type+.
@@ -33,13 +33,13 @@ module Jenkins
     # +log_rotate+    - define log rotation
     def initialize(job_type = :ruby, &block)
       self.job_type = job_type.to_s if job_type
-      
+
       yield self
 
       self.scm_branches ||= ["master"]
       raise InvalidTemplate unless VALID_JOB_TEMPLATES.include?(job_type.to_s)
     end
-  
+
     def builder
       b = Builder::XmlMarkup.new :indent => 2
       b.instruct!
@@ -63,13 +63,13 @@ module Jenkins
         b.runSequentially false if matrix_project?
       end
     end
-  
+
     def to_xml
       builder.to_s
     end
-  
+
     protected
-    
+
     # <scm class="hudson.plugins.git.GitSCM"> ... </scm>
     def build_scm(b)
       if scm && scm =~ /git/
@@ -92,7 +92,7 @@ module Jenkins
               b.string
             end
           end
-        
+
           if scm_branches
             b.branches do
               scm_branches.each do |branch|
@@ -102,7 +102,7 @@ module Jenkins
               end
             end
           end
-        
+
           b.localBranch
           b.mergeOptions
           b.recursiveSubmodules false
@@ -123,7 +123,7 @@ module Jenkins
     def matrix_project?
       !(rubies.blank? && node_labels.blank?)
     end
-  
+
     # <hudson.matrix.TextAxis>
     #   <name>RUBY_VERSION</name>
     #   <values>
@@ -164,7 +164,7 @@ module Jenkins
         end
       end
     end
-    
+
     # Example:
     # <buildWrappers>
     #   <hudson.plugins.envfile.EnvFileBuildWrapper>
@@ -279,7 +279,7 @@ module Jenkins
         b.publishers
       end
     end
-    
+
     # The important sequence of steps that are run to process a job build.
     # Can be defaulted by the +job_type+ using +default_steps(job_type)+,
     # or customized via +steps+ array.
@@ -292,7 +292,7 @@ module Jenkins
         end
       end
     end
-    
+
     def default_steps(job_type)
       steps = case job_type.to_sym
       when :rails, :rails3
@@ -331,14 +331,14 @@ module Jenkins
       end
       rubies.blank? ? steps : default_rvm_steps + steps
     end
-    
+
     def default_rvm_steps
       [
         [:build_shell_step, "rvm $RUBY_VERSION"],
         [:build_shell_step, "rvm gemset create ruby-$RUBY_VERSION && rvm gemset use ruby-$RUBY_VERSION"]
       ]
     end
-    
+
     # <hudson.tasks.Shell>
     #   <command>echo &apos;THERE ARE NO STEPS! Except this one...&apos;</command>
     # </hudson.tasks.Shell>
@@ -363,7 +363,7 @@ module Jenkins
         end
       end
     end
-  
+
     # Usage: build_ruby_step b, "db:schema:load"
     #
     # <hudson.plugins.rake.Rake>
@@ -384,7 +384,7 @@ module Jenkins
         b.silent false
       end
     end
-    
+
     # Converts git@github.com:drnic/newgem.git into git://github.com/drnic/newgem.git
     def public_only_git_scm(scm_url)
       if scm_url =~ /git@([\w\-_.]+):(.+)\.git/

--- a/ruby-tools/cli/spec/api_spec.rb
+++ b/ruby-tools/cli/spec/api_spec.rb
@@ -1,8 +1,7 @@
 require File.dirname(__FILE__) + "/spec_helper"
 
 describe Jenkins::Api do
-  context "#setup_base_url" do
-
+  describe "#setup_base_url" do
     it "should accept a hash with a host and port as an argument" do
       uri = Jenkins::Api.setup_base_url :host => 'hash.example.com', :port => '123'
       uri.host.should == 'hash.example.com'


### PR DESCRIPTION
Since Jenkins::Api is hitting the JSON API, there's no reasonable way to export
XML from the job details

This commit also includes a few whitespace and formatting fixes

Fixes #17
