### PR TITLE
Add missing require

### DIFF
--- a/ruby-tools/cli/lib/jenkins/config.rb
+++ b/ruby-tools/cli/lib/jenkins/config.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 module Jenkins
   module Config
     extend self


### PR DESCRIPTION
Previously this was causing a `NameError`:

```
$ ruby -rjenkins -e 'Jenkins::Config.store!'
~/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/jenkins-0.6.8/lib/jenkins/config.rb:19:in `store!': uninitialized constant Jenkins::Config::FileUtils (NameError)
    from -e:1:in `<main>'
```
