### PR TITLE
fix pathname bug when running in jruby in 1.9 mode.

### DIFF
--- a/ruby-runtime/lib/jenkins/plugin/runtime/version.rb
+++ b/ruby-runtime/lib/jenkins/plugin/runtime/version.rb
@@ -1,7 +1,7 @@
 module Jenkins
   class Plugin
     module Runtime
-      VERSION = "0.2.2"
+      VERSION = "0.2.3"
     end
   end
 end

--- a/ruby-runtime/lib/jenkins/plugin/specification.rb
+++ b/ruby-runtime/lib/jenkins/plugin/specification.rb
@@ -106,7 +106,7 @@ module Jenkins
       #
       # @return [Jenkins::Plugin::Specification] the loaded specification
       def self.load(path)
-        eval(File.read(path), binding, path, 1)
+        eval(File.read(path.to_s), binding, path.to_s, 1)
       end
 
       # Looks inside `dir` for a file ending in .pluginspec, and if found,


### PR DESCRIPTION
when running jruby in 1.9 compat mode, jenkins-plugin-runtime fails
with the following error:
  jenkins-plugin-runtime-0.2.2/lib/jenkins/plugin/specification.rb:109:in `eval': can't convert Pathname into String (TypeError)

this commit allows the gem to work in both 1.8 and 1.9 by explicitly
converting the Pathname to String.

the difference in how Pathnames are handled can be illustrated in the shell:
$ echo "puts 'ok'" > foo
$ JRUBY_OPTS=--1.8 ruby -e "puts RUBY_VERSION; require 'pathname'; p = Pathname.new('foo'); eval(File.read(p), nil, p, 0)"
1.8.7
ok
$ JRUBY_OPTS=--1.9 ruby -e "puts RUBY_VERSION; require 'pathname'; p = Pathname.new('foo'); eval(File.read(p), nil, p, 0)"
1.9.2
TypeError: can't convert Pathname into String
    eval at org/jruby/RubyKernel.java:1088
  (root) at -e:1
