### PR TITLE
Bump httparty requirement to ~> 0.7.0.

### DIFF
--- a/ruby-tools/cli/jenkins.gemspec
+++ b/ruby-tools/cli/jenkins.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("term-ansicolor", ">= 1.0.4")
-  s.add_dependency("httparty", "~> 0.6.1")
+  s.add_dependency("httparty", "~> 0.7.0")
   s.add_dependency("builder", "~> 2.1.2")
   s.add_dependency("thor", "~> 0.15.0")
   s.add_dependency("hpricot")


### PR DESCRIPTION
This resolves a versioning conflict with other useful gems like aws-sdk.
