### PR TITLE
Configure custom jobs from file or uri

### DIFF
--- a/ruby-tools/cli/README.md
+++ b/ruby-tools/cli/README.md
@@ -61,7 +61,9 @@ To add Jobs/Projects (create a Job) on a Jenkins server:
 
     Usage: jenkins create PROJECT_PATH [options]
         --public-scm                     	  use public scm URL
-        --template [ruby]                	  template of job steps (available: rails,rails3,ruby,rubygem,erlang)
+        --template [ruby]                	  built-in template of job steps (available: rails,rails3,ruby,rubygem,erlang)
+        --no-template                             do not use built-in template (removes Rubygems requirement)
+        --custom-template [FILE_OR_URI[           use raw config located at FILE_OR_URI for job steps
         --assigned-node [ASSIGNED-NODE]  	  only use slave nodes with this label
         --override                       	  override if job exists
         --no-build                       	  create job without initial build

--- a/ruby-tools/cli/features/manage_jobs.feature
+++ b/ruby-tools/cli/features/manage_jobs.feature
@@ -219,6 +219,20 @@ Feature: Create and manage jobs
           </hudson.tasks.Shell>
         </builders>
       """
+  
+  Scenario: Create job with config from file (jenkins create --template /path/to/config.xml)
+    Given I am in the "custom-config" project folder
+    And the project uses "git" scm
+    When I run local executable "jenkins" with arguments "create . --custom-template custom-config.xml --host localhost --port 3010"
+    Then I should see "Added custom project 'custom-config' to Jenkins."
+    And the job "custom-config" config "builders" should be:
+      """
+      <builders>
+          <hudson.tasks.Shell>
+            <command>echo &quot;THERE ARE NO STEPS! Except this custom step from a file...&quot;</command>
+          </hudson.tasks.Shell>
+        </builders>
+      """
 
   Scenario: Reject projects that don't use bundler (jenkins create)
     Given I am in the "non-bundler" project folder

--- a/ruby-tools/cli/fixtures/projects/custom-config/Gemfile
+++ b/ruby-tools/cli/fixtures/projects/custom-config/Gemfile
@@ -1,0 +1,3 @@
+source "http://rubygems.org"
+
+gem "rack"

--- a/ruby-tools/cli/fixtures/projects/custom-config/Rakefile
+++ b/ruby-tools/cli/fixtures/projects/custom-config/Rakefile
@@ -1,0 +1,4 @@
+desc "Default task runs tests"
+task :default do
+  puts "Tests ran successfully!"
+end

--- a/ruby-tools/cli/fixtures/projects/custom-config/custom-config.xml
+++ b/ruby-tools/cli/fixtures/projects/custom-config/custom-config.xml
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers class="vector"/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>echo &quot;THERE ARE NO STEPS! Except this custom step from a file...&quot;</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/ruby-tools/cli/lib/jenkins/api.rb
+++ b/ruby-tools/cli/lib/jenkins/api.rb
@@ -71,9 +71,10 @@ module Jenkins
     def self.create_job(name, job_config, options = {})
       options = options.with_clean_keys
       delete_job(name) if options[:override]
+      body = job_config.respond_to?(:to_xml) ? job_config.to_xml : job_config
       begin
         res = post "/createItem/api/xml?name=#{CGI.escape(name)}", {
-          :body => job_config.to_xml, :format => :xml, :headers => { 'content-type' => 'application/xml' }
+          :body => body, :format => :xml, :headers => { 'content-type' => 'application/xml' }
         }
         if res.code.to_i == 200
           cache_configuration!
@@ -95,8 +96,9 @@ module Jenkins
     #
     # TODO Exceptions?
     def self.update_job(name, job_config)
+      body = job_config.respond_to?(:to_xml) ? job_config.to_xml : job_config
       res = post "#{job_url name}/config.xml", {
-        :body => job_config.to_xml, :format => :xml, :headers => { 'content-type' => 'application/xml' }
+        :body => body, :format => :xml, :headers => { 'content-type' => 'application/xml' }
       }
       if res.code.to_i == 200
         cache_configuration!


### PR DESCRIPTION
Just picking up https://github.com/jenkinsci/jenkins.rb/pull/32 here

Adds a `--custom-template` option that takes a path to a file or a URI that is then used as raw custom config for the build.
