### PR TITLE
Load jpi code from local files

### DIFF
--- a/ruby-tools/jpi/bin/jpi
+++ b/ruby-tools/jpi/bin/jpi
@@ -1,5 +1,8 @@
 #!/usr/bin/env ruby
 
+$:.unshift(File.expand_path("../../lib", __FILE__))
 require 'jenkins/plugin/cli'
 
-Jenkins::Plugin::CLI.start ARGV
+Jenkins::Plugin::CLI.start(ARGV)
+
+


### PR DESCRIPTION
This is useful for using jpi whilst in local development to ensure it uses 
the local code; not the installed gem
