### PR TITLE
Set default for war parameter on Jenkins::Plugin::Tools::Server.initialize.

### DIFF
--- a/ruby-tools/jpi/lib/jenkins/plugin/tools/server.rb
+++ b/ruby-tools/jpi/lib/jenkins/plugin/tools/server.rb
@@ -9,7 +9,7 @@ module Jenkins
     module Tools
       class Server
 
-        def initialize(spec, workdir, war)
+        def initialize(spec, workdir, war = nil)
           @spec = spec
           @workdir = workdir
           @plugindir = "#{workdir}/plugins"


### PR DESCRIPTION
Running `rake server` fails due to an invalid call in Jenkins::Rake.install to initialize Jenkins:Plugin::Tools::Server. It's passing in 2 args and 3 are required.

This pull request make the 3rd argument, war, optional with a default value of nil. The initialize method then sets a better default, since nil is false-y.

I chose to modify the initialize signature because it was already handling false-y values for the war parameter. Another fix would be to pass `nil` as the third argument in the rake server task.

The rake server task trace looks like this:

```
$ rake server --trace
** Invoke server (first_time)
** Execute server
rake aborted!
wrong number of arguments calling `initialize` (2 for 3)
/home/thomas/.rvm/gems/jruby-1.7.3/gems/jpi-0.3.8/lib/jenkins/rake.rb:47:in `install'
org/jruby/RubyProc.java:249:in `call'
/home/thomas/.rvm/gems/jruby-1.7.3@global/gems/rake-10.0.4/lib/rake/task.rb:246:in `execute'
org/jruby/RubyArray.java:1613:in `each'
/home/thomas/.rvm/gems/jruby-1.7.3@global/gems/rake-10.0.4/lib/rake/task.rb:241:in `execute'
/home/thomas/.rvm/gems/jruby-1.7.3@global/gems/rake-10.0.4/lib/rake/task.rb:184:in `invoke_with_call_chain'
/home/thomas/.rvm/rubies/jruby-1.7.3/lib/ruby/1.9/monitor.rb:211:in `mon_synchronize'
/home/thomas/.rvm/gems/jruby-1.7.3@global/gems/rake-10.0.4/lib/rake/task.rb:177:in `invoke_with_call_chain'
/home/thomas/.rvm/gems/jruby-1.7.3@global/gems/rake-10.0.4/lib/rake/task.rb:170:in `invoke'
/home/thomas/.rvm/gems/jruby-1.7.3@global/gems/rake-10.0.4/lib/rake/application.rb:143:in `invoke_task'
/home/thomas/.rvm/gems/jruby-1.7.3@global/gems/rake-10.0.4/lib/rake/application.rb:101:in `top_level'
org/jruby/RubyArray.java:1613:in `each'
/home/thomas/.rvm/gems/jruby-1.7.3@global/gems/rake-10.0.4/lib/rake/application.rb:101:in `top_level'
/home/thomas/.rvm/gems/jruby-1.7.3@global/gems/rake-10.0.4/lib/rake/application.rb:110:in `run_with_threads'
/home/thomas/.rvm/gems/jruby-1.7.3@global/gems/rake-10.0.4/lib/rake/application.rb:95:in `top_level'
/home/thomas/.rvm/gems/jruby-1.7.3@global/gems/rake-10.0.4/lib/rake/application.rb:73:in `run'
/home/thomas/.rvm/gems/jruby-1.7.3@global/gems/rake-10.0.4/lib/rake/application.rb:160:in `standard_exception_handling'
/home/thomas/.rvm/gems/jruby-1.7.3@global/gems/rake-10.0.4/lib/rake/application.rb:70:in `run'
/home/thomas/.rvm/gems/jruby-1.7.3@global/gems/rake-10.0.4/bin/rake:33:in `(root)'
org/jruby/RubyKernel.java:1046:in `load'
/home/thomas/.rvm/gems/jruby-1.7.3@global/bin/rake:1:in `(root)'
org/jruby/RubyKernel.java:1066:in `eval'
/home/thomas/.rvm/gems/jruby-1.7.3/bin/ruby_noexec_wrapper:14:in `(root)'
Tasks: TOP => server
```
