### PR TITLE
Added the unprotected root action support

### DIFF
--- a/ruby-runtime/lib/jenkins/model/unprotected_root_action.rb
+++ b/ruby-runtime/lib/jenkins/model/unprotected_root_action.rb
@@ -1,0 +1,8 @@
+
+module Jenkins
+  module Model
+    class UnprotectedRootAction
+      include Jenkins::Model::Action
+    end
+  end
+end

--- a/ruby-runtime/lib/jenkins/model/unprotected_root_action_proxy.rb
+++ b/ruby-runtime/lib/jenkins/model/unprotected_root_action_proxy.rb
@@ -1,0 +1,7 @@
+module Jenkins::Model
+  class UnprotectedRootActionProxy
+    include ActionProxy
+    include Java.hudson.model.UnprotectedRootAction
+    proxy_for Jenkins::Model::UnprotectedRootAction
+  end
+end


### PR DESCRIPTION
Needed this for [Gitlab Hook Plugin](https://github.com/elvanja/jenkins-gitlab-hook-plugin) where the hook needs to be accessible anonymously. Currently fixed directly in the plugin itself: https://github.com/elvanja/jenkins-gitlab-hook-plugin/blob/master/models/gitlab_web_hook_root_action.rb#L3
But, it would be nice to have the support directly.
