### PR TITLE
Allow recent version of builder, so we can use this gem in a rails 3 app

### DIFF
--- a/ruby-tools/cli/jenkins.gemspec
+++ b/ruby-tools/cli/jenkins.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("term-ansicolor", ">= 1.0.4")
   s.add_dependency("httparty", "~> 0.7.0")
-  s.add_dependency("builder", "~> 2.1.2")
+  s.add_dependency("builder", ">= 2.1.2")
   s.add_dependency("thor", "~> 0.15.0")
   s.add_dependency("hpricot")
   s.add_dependency("json_pure", ">= 1.5.1")

--- a/ruby-tools/cli/lib/jenkins/version.rb
+++ b/ruby-tools/cli/lib/jenkins/version.rb
@@ -1,3 +1,3 @@
 module Jenkins
-  VERSION = "0.6.8"
+  VERSION = "0.6.9"
 end


### PR DESCRIPTION
Fixes Issue #78
Allows recent version of the builder gem, which allows us to use this gem in a rails 3 app. Rails 3 requires builder version at least 3.0.0. This change allows jenkins 0.6.9 and rails 3.2.13 to co-exist in a bundle. 
