### PR TITLE
Consider --port option for `jpi server`.

### DIFF
--- a/ruby-tools/jpi/lib/jenkins/plugin/cli.rb
+++ b/ruby-tools/jpi/lib/jenkins/plugin/cli.rb
@@ -38,11 +38,11 @@ module Jenkins
 
       desc "server", "run a test server with plugin"
       method_option :home, :desc => "set server work directory", :default => 'work'
-      method_option :port, :desc => "server http port (currently ignored)", :default => 8080
+      method_option :port, :desc => "server http port", :default => 8080
       method_option :war,  :desc => "specify a custom jenkins.war to run the plugin with"
       def server
         require 'jenkins/plugin/tools/server'
-        server = Tools::Server.new(spec, options[:home], options[:war])
+        server = Tools::Server.new(spec, options[:home], options[:war], options[:port])
         server.run!
       end
       map "s" => "server"

--- a/ruby-tools/jpi/lib/jenkins/plugin/tools/server.rb
+++ b/ruby-tools/jpi/lib/jenkins/plugin/tools/server.rb
@@ -9,11 +9,12 @@ module Jenkins
     module Tools
       class Server
 
-        def initialize(spec, workdir, war)
+        def initialize(spec, workdir, war, port)
           @spec = spec
           @workdir = workdir
           @plugindir = "#{workdir}/plugins"
           @war = war || Jenkins::War::LOCATION
+          @port = port
         end
 
         def run!
@@ -49,6 +50,9 @@ module Jenkins
           args << "-jar"
           args << @war
           args << ENV['JENKINS_OPTS'] if ENV.key? 'JENKINS_OPTS'
+          unless ENV.key?('JENKINS_OPTS') && !ENV['JENKINS_OPTS'].index("--httpPort=").nil?
+            args << "--httpPort=#{@port}"
+          end
           exec args.join(' ')
         end
       end


### PR DESCRIPTION
- Consider `--port` option for `jpi server`.
- When `--httpPort` is specified in `JENKINS_OPTS`, `--port` option is ignored.

```
$ jpi server --port=8081
...
INFO: HTTP Listener started: port=8081
...
```

```
$ JENKINS_OPTS="--httpPort=8082" jpi server
...
INFO: HTTP Listener started: port=8082
...
```

```
$ JENKINS_OPTS="--httpPort=8082" jpi server --port=8081
...
INFO: HTTP Listener started: port=8082
...
```
