### PR TITLE
Fix unresolvable dependency of stapler 1.208-SNAPSHOT

### DIFF
--- a/java-runtime/pom.xml
+++ b/java-runtime/pom.xml
@@ -15,7 +15,7 @@
       <dependency>
         <groupId>org.kohsuke.stapler</groupId>
         <artifactId>stapler-jruby</artifactId>
-        <version>1.208-SNAPSHOT</version>
+        <version>1.209</version>
         <exclusions>
           <exclusion>
             <groupId>org.kohsuke.stapler</groupId>


### PR DESCRIPTION
Update stapler from 1.208-SNAPSHOT to 1.209 to fix Maven build of java-runtime.

I skipped stapler 1.208(-SNAPSHOT)? since it seems to not deployed to http://repo.jenkins-ci.org by the problem of Maven configuration at stapler/stapler@03c56ad8c976083d9526f56a21640e6b0c0bc14b
