### PR TITLE
changed Gemfile's source to https

### DIFF
--- a/ruby-tools/jpi/lib/jenkins/plugin/cli/templates/Gemfile.tt
+++ b/ruby-tools/jpi/lib/jenkins/plugin/cli/templates/Gemfile.tt
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem "jenkins-plugin-runtime", "~> <%= Jenkins::Plugin::RUNTIME_VERSION_DEPENDENCY %>"


### PR DESCRIPTION
changed Gemfile's source for bundle warning

$ bundle -v
Bundler version 1.3.5

$ bundle
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
