### PR TITLE
Fix loading of Ruby plugins.

### DIFF
--- a/java-runtime/src/main/java/ruby/RubyPlugin.java
+++ b/java-runtime/src/main/java/ruby/RubyPlugin.java
@@ -194,12 +194,14 @@ public class RubyPlugin extends PluginImpl {
 
         File classesJar = new File(new File(url.getPath()), "WEB-INF/lib/classes.jar");
 
-        Expand e = new Expand();
-        e.setProject(new Project());
-        e.setTaskType("unzip");
-        e.setSrc(classesJar);
-        e.setDest(getScriptDir());
-        e.execute();
+        if (!getScriptDir().exists() && classesJar.exists()) {
+            Expand e = new Expand();
+            e.setProject(new Project());
+            e.setTaskType("unzip");
+            e.setSrc(classesJar);
+            e.setDest(getScriptDir());
+            e.execute();
+        }
     }
 
 	private void initRubyLoadPaths() throws Exception {
@@ -288,7 +290,7 @@ public class RubyPlugin extends PluginImpl {
         if (!url.getProtocol().equals("file"))
             throw new IllegalStateException("Unexpected base resource URL: "+url);
 
-        return new File(new File(url.getPath()),"WEB-INF/lib/classes");
+        return new File(new File(url.getPath()),"WEB-INF/classes");
     }
 
     public File getLibPath() {


### PR DESCRIPTION
In Jenkins 1.519 a change was made to move plugin classes into WEB-INF/lib/classes.jar rather than unpacked into WEB-INF/classes/.

This change causes the ruby runtime to unpack the classes.jar file to WEB-INF/lib/classes/ when it loads a ruby plugin. It also changes the load paths to look for the extra /lib in the file path.

I tested this with the RVM plugin, and it successfully installed the plugin, unpacked the classes.jar file, allowed me to set up a project with RVM, and successfully loaded that project after restarting Jenkins with no data loss.

Fixes [JENKINS-18528](https://issues.jenkins-ci.org/browse/JENKINS-18528).
