### PR TITLE
Add an alias of java.io.PrintStream#write(String) to fix #86

### DIFF
--- a/java-runtime/src/main/java/ruby/RubyPlugin.java
+++ b/java-runtime/src/main/java/ruby/RubyPlugin.java
@@ -179,6 +179,10 @@ public class RubyPlugin extends PluginImpl {
     }
 
 	private void initRubyNativePlugin() {
+		// Add an alias of PrintStream#write for backward compatibility
+		// https://github.com/jenkinsci/jenkins.rb/issues/86
+		require("core_ext/print_stream");
+
 		require("jenkins/plugin/runtime");
 		Object pluginClass = eval("Jenkins::Plugin");
 		this.plugin = callMethod(pluginClass, "initialize", this);

--- a/java-runtime/src/main/resources/core_ext/print_stream.rb
+++ b/java-runtime/src/main/resources/core_ext/print_stream.rb
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+# -*- encoding: utf-8 -*-
+
+require "java"
+
+# Add an alias of PrintStream#write for backward compatibility
+# https://github.com/jenkinsci/jenkins.rb/issues/86
+java_import java.io.PrintStream
+class PrintStream
+  java_alias(:write, :print, [java.lang.String])
+end
+
+# vim:set ft=ruby :


### PR DESCRIPTION
Declare `java.io.PrintStream#write(String)` as an alias of `java.io.PrintStream#println(String)` to fix the problem of rvm plugin described in #86.
