### PR TITLE
conflict with rspec and rspec-spies

### DIFF
--- a/ruby-runtime/jenkins-plugin-runtime.gemspec
+++ b/ruby-runtime/jenkins-plugin-runtime.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency "slop", "~> 3.0.2"
 
   s.add_development_dependency "rake"
-  s.add_development_dependency "rspec"
-  s.add_development_dependency "rspec-spies", ">= 2.1.3"
+  s.add_development_dependency "rspec", "~> 2.14.1"
   s.add_development_dependency "jenkins-war", "> 1.445"
 end

--- a/ruby-runtime/spec/jenkins/listeners/item_listener_proxy_spec.rb
+++ b/ruby-runtime/spec/jenkins/listeners/item_listener_proxy_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'rspec-spies'
 
 describe Jenkins::Listeners::ItemListenerProxy do
   include ProxyHelper

--- a/ruby-runtime/spec/jenkins/listeners/run_listener_proxy_spec.rb
+++ b/ruby-runtime/spec/jenkins/listeners/run_listener_proxy_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'rspec-spies'
 
 describe Jenkins::Listeners::RunListenerProxy do
   include ProxyHelper

--- a/ruby-runtime/spec/jenkins/model/describable_spec.rb
+++ b/ruby-runtime/spec/jenkins/model/describable_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'rspec-spies'
 describe Jenkins::Model::Describable do
 
   before do

--- a/ruby-runtime/spec/jenkins/plugin/proxy_spec.rb
+++ b/ruby-runtime/spec/jenkins/plugin/proxy_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'rspec-spies'
 
 describe "a class with #{Jenkins::Plugin::Proxy} mixed in" do
 

--- a/ruby-runtime/spec/jenkins/plugin_spec.rb
+++ b/ruby-runtime/spec/jenkins/plugin_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'rspec-spies'
 require 'tmpdir'
 
 describe Jenkins::Plugin do


### PR DESCRIPTION
The development dependency in jenkins-plugin-runtime.gemspec has rspec not locked down so a fresh bundle might give you rspec 2.14 which has rspec-spies included. This causes specs to fail because mocks are called twice.

```
Failures:

  1) Jenkins::Plugin registering an extension. when no order is defined uses 0
     Failure/Error: @peer.should have_received(:addExtension).with(@ext, 0)
       (Mock).addExtension(#<Object:0x21f9277b>, 0)
           expected: 1 time with arguments: (#<Object:0x21f9277b>, 0)
           received: 2 times with arguments: (#<Object:0x21f9277b>, 0)
     # ./spec/jenkins/plugin_spec.rb:45:in `(root)'
```

We can either lock the rspec version or update the gemspec and remove rspec-spies. I'd be happy to submit a pull request for either. 
