### PR TITLE
Change to use rubyzip 1.1.0 or newer

### DIFF
--- a/ruby-tools/jpi/Gemfile
+++ b/ruby-tools/jpi/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in jenkins-plugins.gemspec
 gemspec

--- a/ruby-tools/jpi/jpi.gemspec
+++ b/ruby-tools/jpi/jpi.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "bundler"
   s.add_dependency "thor"
-  s.add_dependency "rubyzip"
+  s.add_dependency "rubyzip", "~> 1.1.0"
   s.add_dependency "jenkins-war", "> 1.427"
   s.add_dependency "jenkins-plugin-runtime", "~> #{Jenkins::Plugin::RUNTIME_VERSION_DEPENDENCY}"
 

--- a/ruby-tools/jpi/lib/jenkins/plugin/tools/hpi.rb
+++ b/ruby-tools/jpi/lib/jenkins/plugin/tools/hpi.rb
@@ -1,4 +1,4 @@
-require 'zip/zip'
+require 'zip'
 require 'net/http'
 require 'uri'
 require 'fileutils'
@@ -15,7 +15,7 @@ module Jenkins
           @file = file
 
           # load and parse manifests
-          Zip::ZipFile.open(@file) do |zip|
+          Zip::File.open(@file) do |zip|
             zip.get_input_stream("META-INF/MANIFEST.MF") do |m|
               # main section of the manifest
               @manifest = parse_manifest(m.read)[0]

--- a/ruby-tools/jpi/lib/jenkins/plugin/tools/package.rb
+++ b/ruby-tools/jpi/lib/jenkins/plugin/tools/package.rb
@@ -1,6 +1,6 @@
 require 'jenkins/plugin/tools/bundle'
 require 'jenkins/plugin/tools/manifest'
-require 'zip/zip'
+require 'zip'
 
 module Jenkins
   class Plugin
@@ -26,7 +26,7 @@ module Jenkins
 
           File.delete file_name if File.exists?(file_name)
 
-          Zip::ZipFile.open(file_name, Zip::ZipFile::CREATE) do |zipfile|
+          Zip::File.open(file_name, Zip::File::CREATE) do |zipfile|
             zipfile.get_output_stream("META-INF/MANIFEST.MF") do |f|
               manifest.write_hpi(f)
               f.puts "Bundle-Path: vendor/gems"

--- a/ruby-tools/jpi/lib/jenkins/rake.rb
+++ b/ruby-tools/jpi/lib/jenkins/rake.rb
@@ -2,7 +2,6 @@ require 'jenkins/plugin/version'
 require 'jenkins/plugin/specification'
 require 'jenkins/plugin/tools/hpi'
 require 'jenkins/plugin/tools/loadpath'
-require 'zip/zip'
 
 module Jenkins
   # given the IO handle, produce the basic manifest entries that are common between hpi and hpl formats


### PR DESCRIPTION
`jpi build` command fails like following:

```
$ jpi build
LoadError: no such file to load -- zip/zip
         require at org/jruby/RubyKernel.java:1084
         require at /Users/eito/Library/Homebrew/Cellar/rbenv/0.4.0/versions/jruby-1.7.8/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:55
         require at /Users/eito/Library/Homebrew/Cellar/rbenv/0.4.0/versions/jruby-1.7.8/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:53
          (root) at /Users/eito/Library/Homebrew/opt/rbenv/versions/jruby-1.7.8/gemsets/rvm-plugin/gems/jpi-0.3.8/lib/jenkins/plugin/tools/package.rb:3
         require at org/jruby/RubyKernel.java:1084
```

This is because jpi picks up the latest rubyzip gem (1.1.0 at this moment) and the gem has changed several things.

This PR should fix this issue to cope with those changes in rubyzip gem.
