### PR TITLE
Default name used if Etc.getlogin() returns NIL

### DIFF
--- a/ruby-tools/jpi/lib/jenkins/plugin/tools/manifest.rb
+++ b/ruby-tools/jpi/lib/jenkins/plugin/tools/manifest.rb
@@ -19,7 +19,7 @@ module Jenkins
           w.put "Created-By", Jenkins::Plugin::VERSION
           w.put "Build-Ruby-Platform", RUBY_PLATFORM
           w.put "Build-Ruby-Version", RUBY_VERSION
-          w.put "Built-By", Etc.getlogin()
+          w.put "Built-By", Etc.getlogin() == NIL ? "default" : Etc.getlogin()
 
           w.put "Group-Id", "org.jenkins-ci.plugins"
           w.put "Short-Name", @spec.name


### PR DESCRIPTION
useful for if you are using docker containers to build your plugins where the login name is empty