### PR TITLE
[JENKINS-48116] Proxy to StreamTaskListener not AbstractTaskListener

### DIFF
--- a/ruby-runtime/lib/jenkins/model/listener.rb
+++ b/ruby-runtime/lib/jenkins/model/listener.rb
@@ -66,7 +66,7 @@ module Jenkins
         @native.getLogger()
       end
 
-      Jenkins::Plugin::Proxies.register self, Java.hudson.util.AbstractTaskListener
+      Jenkins::Plugin::Proxies.register self, Java.hudson.util.StreamTaskListener
     end
   end
 end


### PR DESCRIPTION
An equivalent patch made directly to `rvm.hpi` allows https://github.com/jenkinsci/acceptance-test-harness/pull/383 to pass even without https://github.com/jenkinsci/jenkins/pull/3154. But I suppose this gem would need to be released and then _every plugin with a dependency on `ruby-runtime` rebuilt_ in order for the fix to actually take effect. Yuck.

@reviewbybees